### PR TITLE
Remove PHP Notice for $output (media editor)

### DIFF
--- a/includes/attachments.php
+++ b/includes/attachments.php
@@ -397,6 +397,7 @@ function file_gallery_copy_attachments_to_post()
 	
 	$post_id 	  = (int) $_POST['post_id'];
 	$attached_ids = $_POST['ids'];
+	$output = "";
 	
 	// get checked attachments
 	if( "" != $attached_ids )


### PR DESCRIPTION
Notice on concatenating to variable that doesn't already exist. Added variable declaration to top of function scope.
