### PR TITLE
Fix for meta_copy

### DIFF
--- a/includes/attachments.php
+++ b/includes/attachments.php
@@ -533,7 +533,7 @@ function file_gallery_copy_attachment_to_post( $aid, $post_id )
 		{
 			foreach( $val as $v )
 			{
-				add_post_meta($attachment_id, $key, $v);
+				add_post_meta($attachment_id, $key, maybe_unserialize($v));
 			}
 		}
 	}


### PR DESCRIPTION
Fix for FileGallery+ WP Offload S3 . [here more](https://wordpress.org/support/topic/file-gallery-wp-offload-s3-cannot-attach-image-that-is-already-uploaded-befo?replies=2#post-8209522)
