### PR TITLE
PHP Fatal error in attachments.php:557

### DIFF
--- a/includes/attachments.php
+++ b/includes/attachments.php
@@ -552,7 +552,7 @@ function file_gallery_copy_attachment_to_post( $aid, $post_id )
 	update_post_meta($attachment_id, '_is_copy_of', $aid);
 	
 	// meta for the original attachment (array holding ids of its copies)
-	$has_copies = get_post_meta($aid, '_has_copies', true);
+	$has_copies = get_post_meta($aid, '_has_copies');
 	$has_copies[] = $attachment_id;
 	$has_copies = array_unique($has_copies);
 	


### PR DESCRIPTION
#36 

$has_copies returns a string because of the third parameter set to true (https://developer.wordpress.org/reference/functions/get_post_meta/)
It should be set to false to returns an array and avoid a fatal error under PHP 7.2