### PR TITLE
Fixed variable initialized as string but then pushed as an array.

### DIFF
--- a/includes/main.php
+++ b/includes/main.php
@@ -491,7 +491,7 @@ function file_gallery_main( $ajax = true )
 		
 		// media_tag taxonomy - attachment tags
 		$tax_input = "";
-		$old_media_tags = "";
+		$old_media_tags = [];
 		
 		$get_old_media_tags = wp_get_object_terms((int) $_POST['attachment_id'], FILE_GALLERY_MEDIA_TAG_NAME);
 		


### PR DESCRIPTION
This triggers PHP Fatal Error on PHP 7.2
Not sure if plugin still maintained but it would be great to have a new release with this small change.
Thanks!!